### PR TITLE
adopt numpydoc standard

### DIFF
--- a/dtemulate/compare.py
+++ b/dtemulate/compare.py
@@ -6,13 +6,23 @@ import numpy as np
 
 def compare(X, y, cv=5, models=None):
     """
-    Compare a list of emulators using K-fold cross-validation.
+    Compare emulator models using K-fold cross-validation.
 
-    :param X: Input data (simulation input).
-    :param y: Target data (simulation output).
-    :param cv: Number of folds for cross-validation.
-    :param model: List of emulators to compare.
-    :return: Scores
+    Parameters
+    ----------
+    X : numpy.ndarray
+        Input data (simulation input).
+    y : numpy.ndarray
+        Target data (simulation output).
+    cv : int
+        Number of folds for cross-validation.
+    models : list
+        List of emulators to compare.
+
+    Returns
+    -------
+    scores : dict
+        Dictionary of scores for each model.
     """
 
     X = np.array(X)

--- a/dtemulate/emulators.py
+++ b/dtemulate/emulators.py
@@ -17,19 +17,38 @@ class Emulator(ABC):
     def fit(self, X, y):
         """Fits the emulator to the data.
 
-        :param X: Input data (simulation input).
-        :param y: Target data (simulation output).
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
+
         """
         pass
 
     @abstractmethod
     def predict(self, X):
-        """Predicts the output of the simulator for a given input."""
+        """Predicts the output of the simulator for a given input.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        """
         pass
 
     @abstractmethod
     def score(self, X, y):
-        """Returns the score of the emulator."""
+        """Returns the score of the emulator.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
+        """
         pass
 
 
@@ -48,8 +67,12 @@ class GaussianProcess(Emulator):
     def fit(self, X, y):
         """Fits the emulator to the data.
 
-        :param X: Input data (simulation input).
-        :param y: Target data (simulation output).
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
         """
         self.model = mogp_emulator.GaussianProcess(X, y, *self.args, **self.kwargs)
         self.model = mogp_emulator.fit_GP_MAP(self.model)
@@ -57,7 +80,15 @@ class GaussianProcess(Emulator):
     def predict(self, X):
         """Predicts the output of the simulator for a given input.
 
-        :param X: Input data (simulation input).
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+
+        Returns
+        -------
+        predictions : numpy.ndarray
+            Predictions of the emulator.
         """
         if self.model is not None:
             return self.model.predict(X)
@@ -65,7 +96,20 @@ class GaussianProcess(Emulator):
             raise ValueError("Emulator not fitted yet.")
 
     def score(self, X, y):
-        """Returns the score of the emulator."""
+        """Returns the score of the emulator.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
+
+        Returns
+        -------
+        rmse : float
+            Root mean squared error of the emulator.
+        """
         predictions_means = self.predict(X).mean
         rmse = np.sqrt(mean_squared_error(y, predictions_means)).round(2)
         return rmse
@@ -86,20 +130,46 @@ class RandomForest(Emulator):
     def fit(self, X, y):
         """Fits the emulator to the data.
 
-        :param X: Input data (simulation input).
-        :param y: Target data (simulation output).
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
         """
         self.model.fit(X, y)
 
     def predict(self, X):
         """Predicts the output of the simulator for a given input.
 
-        :param X: Input data (simulation input).
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+
+        Returns
+        -------
+        predictions : numpy.ndarray
+            Predictions of the emulator.
         """
         return self.model.predict(X)
 
     def score(self, X, y):
-        """Returns the score of the emulator."""
+        """Returns the score of the emulator.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input data (simulation input).
+        y : numpy.ndarray
+            Target data (simulation output).
+
+        Returns
+        -------
+        rmse : float
+            Root mean squared error of the emulator.
+
+        """
         predictions = self.predict(X)
         rmse = np.sqrt(mean_squared_error(y, predictions)).round(2)
         return rmse

--- a/dtemulate/experimental_design.py
+++ b/dtemulate/experimental_design.py
@@ -6,10 +6,12 @@ class ExperimentalDesign(ABC):
     def __init__(self, bounds_list):
         """Initializes a Sampler object.
 
-        :param bounds_list: List tuples with two numeric values.
-                            Each tuple corresponds to the lower and
-                            upper bounds of a parameter.
-        :type bounds_list: list
+        Parameters
+        ----------
+        bounds_list : list
+            List tuples with two numeric values.
+            Each tuple corresponds to the lower and
+            upper bounds of a parameter.
         """
         pass
 
@@ -17,8 +19,10 @@ class ExperimentalDesign(ABC):
     def sample(self, n: int):
         """Samples n points from the sample space.
 
-        :param n: The number of points to sample.
-        :type n: int
+        Parameters
+        ----------
+        n : int
+            The number of points to sample.
         """
         pass
 
@@ -26,8 +30,10 @@ class ExperimentalDesign(ABC):
     def get_n_parameters(self):
         """Returns the number of parameters in the sample space.
 
-        :return: The number of parameters in the sample space.
-        :rtype: int
+        Returns
+        -------
+        n_parameters : int
+            The number of parameters in the sample space.
         """
         pass
 
@@ -36,27 +42,36 @@ class LatinHypercube(ExperimentalDesign):
     def __init__(self, bounds_list):
         """Initializes a LatinHypercube object.
 
-        :param bounds_list: List tuples with two numeric values.
-                            Each tuple corresponds to the lower and
-                            upper bounds of a parameter.
-        :type bounds_list: list
+        Parameters
+        ----------
+        bounds_list : list
+            List tuples with two numeric values.
+            Each tuple corresponds to the lower and
+            upper bounds of a parameter.
         """
         self.sampler = mogp_emulator.LatinHypercubeDesign(bounds_list)
 
     def sample(self, n: int):
         """Samples n points from the sample space.
 
-        :param n: The number of points to sample.
-        :type n: int
-        :return: A numpy array of shape (n, dim) containing the sampled points.
-        :rtype: numpy.ndarray
+        Parameters
+        ----------
+        n : int
+            The number of points to sample.
+
+        Returns
+        -------
+        samples : numpy.ndarray
+            A numpy array of shape (n, dim) containing the sampled points.
         """
         return self.sampler.sample(n)
 
     def get_n_parameters(self):
         """Returns the number of parameters in the sample space.
 
-        :return: The number of parameters in the sample space.
-        :rtype: int
+        Returns
+        -------
+        n_parameters : int
+            The number of parameters in the sample space.
         """
         return self.sampler.get_n_parameters()


### PR DESCRIPTION
Changing docstring style to [numpydoc standard](https://numpydoc.readthedocs.io/en/latest/format.html) to be consistent with the scientific python package ecosystem.